### PR TITLE
Fix pagelinks definition

### DIFF
--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -369,7 +369,7 @@ impl_row_from_sql! {
         namespace: PageNamespace,
         title: PageTitle,
         from_namespace: PageNamespace,
-        target_id: Option<PageId>,
+        target: Option<PageId>,
     }
 }
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -369,6 +369,7 @@ impl_row_from_sql! {
         namespace: PageNamespace,
         title: PageTitle,
         from_namespace: PageNamespace,
+        target_id: Option<PageId>,
     }
 }
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -367,7 +367,7 @@ impl_row_from_sql! {
     PageLink {
         from: PageId,
         from_namespace: PageNamespace,
-        target: Option<PageId>,
+        target: PageId,
     }
 }
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -367,7 +367,7 @@ impl_row_from_sql! {
     PageLink {
         from: PageId,
         from_namespace: PageNamespace,
-        target: PageId,
+        target: LinkTargetId,
     }
 }
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -366,8 +366,6 @@ impl_row_from_sql! {
     pagelinks
     PageLink {
         from: PageId,
-        namespace: PageNamespace,
-        title: PageTitle,
         from_namespace: PageNamespace,
         target: Option<PageId>,
     }


### PR DESCRIPTION
This parses the current version correctly but is not backwards compatible. Is that OK? It doesn't look easy to make a field totally optional, right?

Here's the change: https://www.mediawiki.org/wiki/Manual:Pagelinks_table#Schema_summary

Resolves #5 